### PR TITLE
Add optional suffix to body_class

### DIFF
--- a/lib/brady.ex
+++ b/lib/brady.ex
@@ -10,13 +10,14 @@ defmodule Brady do
       Brady.body_class(conn) => 'cool-widgets cool-widgets-show'"
 
   """
-  @spec body_class(%Plug.Conn{}) :: String.t
-  def body_class(conn = %Plug.Conn{private: %{phoenix_controller: _}}) do
-    controller_name = format_controller_name(conn)
+  @spec body_class(%Plug.Conn{}, %{}) :: String.t
+  def body_class(conn, opts \\ %{})
+  def body_class(conn = %Plug.Conn{private: %{phoenix_controller: _}}, opts) do
+    controller_name = format_controller_name(conn, opts[:suffix])
     "#{format_path(conn)} #{controller_name} #{controller_name}-#{Controller.action_name(conn)}"
     |> String.trim
   end
-  def body_class(_) do
+  def body_class(_, _) do
     ""
   end
 
@@ -31,6 +32,9 @@ defmodule Brady do
       Integer.parse(item) == :error
     end
   end
+
+  defp format_controller_name(conn, nil), do: format_controller_name(conn)
+  defp format_controller_name(conn, suffix), do: format_controller_name(conn) <> "-#{suffix}"
 
   defp format_controller_name(conn) do
     conn

--- a/test/brady_test.exs
+++ b/test/brady_test.exs
@@ -39,6 +39,16 @@ defmodule BradyTest do
     assert Brady.body_class(conn) == ""
   end
 
+  test "body_class with suffix adds suffix to controller name" do
+    conn = %Conn{
+      private: %{
+        phoenix_action: :index,
+        phoenix_controller: Test.PostController
+      }}
+
+    assert Brady.body_class(conn, suffix: "page") == "post-page post-page-index"
+  end
+
   describe "path" do
     test "it includes the path in the class name" do
       conn = %Conn{


### PR DESCRIPTION
I needed this to work Brady into an existing app I'm working on because it had caused some styles to collide. eg: `PostController` would have `body.post`, but I'm already using  `.post` to style posts.
