### PR TITLE
Return empty string if no controller is present 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
 elixir:
-  - 1.2.0
+  - 1.3.0
 notifications:
   email: false

--- a/lib/brady.ex
+++ b/lib/brady.ex
@@ -11,10 +11,13 @@ defmodule Brady do
 
   """
   @spec body_class(%Plug.Conn{}) :: String.t
-  def body_class(conn) do
+  def body_class(conn = %Plug.Conn{private: %{phoenix_controller: _}}) do
     controller_name = format_controller_name(conn)
     "#{format_path(conn)} #{controller_name} #{controller_name}-#{Controller.action_name(conn)}"
     |> String.trim
+  end
+  def body_class(_) do
+    ""
   end
 
   defp format_path(conn) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Brady.Mixfile do
   def project do
     [app: :brady,
      version: "0.0.4",
-     elixir: "~> 1.2",
+     elixir: "~> 1.3",
      description: "Template helpers for Phoenix applications",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/brady_test.exs
+++ b/test/brady_test.exs
@@ -33,6 +33,12 @@ defmodule BradyTest do
     assert Brady.body_class(conn) == "more-page more-page-index"
   end
 
+  test "returns an empty string if no controller is present" do
+    conn = %Conn{private: %{}}
+
+    assert Brady.body_class(conn) == ""
+  end
+
   describe "path" do
     test "it includes the path in the class name" do
       conn = %Conn{


### PR DESCRIPTION
* This allows users to render a template directly without going through a
controller. Previously, Brady would blow up since it could not generate
a body_class with no controller

* This also fixes our failing build by upgrading to Elixir 1.3 to have access to the `ExUnit.Case` `describe` function.
