### PR TITLE
Add inline_svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ name. For example, The WidgetsController#show action would produce:
 
 `widgets widgets-show`
 
+### Inline SVG
+
+The inline_svg function can be used like:
+
+`Brady.inline_svg("foo", class: "bar")`
+
+This will embed the html safe raw svg in your markup, with any CSS attributes
+that you've specified.
+
+` {:safe, "<svg class=\"foo\" data-role=\"bar\" height=\"100\" width=\"100\"><desc>This is a test svg</desc><circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\"></circle></svg>"}`
+
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ name. For example, The WidgetsController#show action would produce:
 The inline_svg function works by passing in your SVG file name and, optionally,
 any CSS attributes you'd like to apply to the SVG.
 
-`Brady.inline_svg("foo", class: "bar")`
+`<%= Brady.inline_svg("foo", class: "bar") %>`
 
 This will embed the html safe raw SVG in your markup.
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,22 @@ name. For example, The WidgetsController#show action would produce:
 
 ### Inline SVG
 
-The inline_svg function can be used like:
+The inline_svg function works by passing in your SVG file name and, optionally,
+any CSS attributes you'd like to apply to the SVG.
 
 `Brady.inline_svg("foo", class: "bar")`
 
-This will embed the html safe raw SVG in your markup, with any CSS attributes
-that you've specified.
+This will embed the html safe raw SVG in your markup.
 
 ` {:safe, "<svg class=\"foo\" data-role=\"bar\" height=\"100\" width=\"100\"><desc>This is a test svg</desc><circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\"></circle></svg>"}`
 
+By default, it looks for files in `web/static/svg/#{file_name}.svg` but you can
+configure this in your config.exs
+
+```elixir
+  config :brady,
+    svg_path: "test/support/svg"
+```
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ any CSS attributes you'd like to apply to the SVG.
 
 This will embed the html safe raw SVG in your markup.
 
-` {:safe, "<svg class=\"bar\" height=\"100\" width=\"100\"><desc>This is a test svg</desc><circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\"></circle></svg>"}`
+`{:safe, ~s(<svg class="foo" data-role="bar" height="100" width="100"><desc>This is a test svg</desc><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></svg>)}`
 
 By default, it looks for files in `web/static/svg/#{file_name}.svg` but you can
 configure this in your config.exs

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ configure this in your config.exs
 
 ```elixir
   config :brady,
-    svg_path: "test/support/svg"
+    svg_path: "web/static/images"
 ```
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ any CSS attributes you'd like to apply to the SVG.
 
 This will embed the html safe raw SVG in your markup.
 
-` {:safe, "<svg class=\"foo\" data-role=\"bar\" height=\"100\" width=\"100\"><desc>This is a test svg</desc><circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\"></circle></svg>"}`
+` {:safe, "<svg class=\"bar\" height=\"100\" width=\"100\"><desc>This is a test svg</desc><circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\"></circle></svg>"}`
 
 By default, it looks for files in `web/static/svg/#{file_name}.svg` but you can
 configure this in your config.exs

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The inline_svg function can be used like:
 
 `Brady.inline_svg("foo", class: "bar")`
 
-This will embed the html safe raw svg in your markup, with any CSS attributes
+This will embed the html safe raw SVG in your markup, with any CSS attributes
 that you've specified.
 
 ` {:safe, "<svg class=\"foo\" data-role=\"bar\" height=\"100\" width=\"100\"><desc>This is a test svg</desc><circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\"></circle></svg>"}`

--- a/config/config.exs
+++ b/config/config.exs
@@ -27,4 +27,4 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-#     import_config "#{Mix.env}.exs"
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :brady, :config,
+  svg_path: "test/support/svg"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
 use Mix.Config
 
-config :brady, :config,
+config :brady,
   svg_path: "test/support/svg"

--- a/lib/brady.ex
+++ b/lib/brady.ex
@@ -55,7 +55,7 @@ defmodule Brady do
 
   defp static_path(file_name) do
     path = Application.get_env(:brady, :svg_path) || "web/static/svg"
-    "#{path}/#{file_name}.svg"
+    Path.join(path, "#{file_name}.svg")
   end
 
   defp format_path(conn) do

--- a/lib/brady.ex
+++ b/lib/brady.ex
@@ -47,7 +47,12 @@ defmodule Brady do
   end
 
   defp static_path(file_name) do
-    "web/static/svg/#{file_name}.svg"
+    path = Application.get_env(:brady, :config)[:svg_path]
+    if path do
+      "#{path}/#{file_name}.svg"
+    else
+      "web/static/svg/#{file_name}.svg"
+    end
   end
 
   defp format_path(conn) do

--- a/lib/brady.ex
+++ b/lib/brady.ex
@@ -21,6 +21,13 @@ defmodule Brady do
   end
 
   @doc """
+  Embeds an html safe raw svg in the markup. Also takes an optional list of CSS
+  attributes and applies those to the svg.
+
+  Ex:
+      Brady.inline_svg("test", class: "foo", "data-role": "bar") =>
+      {:safe,
+       "<svg class=\"foo\" data-role=\"bar\" height=\"100\" width=\"100\"><desc>This is a test svg</desc><circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\"></circle></svg>"}
   """
   @spec inline_svg(String.t, keyword) :: String.t
   def inline_svg(file_name, options \\ []) do

--- a/lib/brady.ex
+++ b/lib/brady.ex
@@ -54,12 +54,8 @@ defmodule Brady do
   end
 
   defp static_path(file_name) do
-    path = Application.get_env(:brady, :svg_path)
-    if path do
-      "#{path}/#{file_name}.svg"
-    else
-      "web/static/svg/#{file_name}.svg"
-    end
+    path = Application.get_env(:brady, :svg_path) || "web/static/svg"
+    "#{path}/#{file_name}.svg"
   end
 
   defp format_path(conn) do

--- a/lib/brady.ex
+++ b/lib/brady.ex
@@ -21,8 +21,8 @@ defmodule Brady do
   end
 
   @doc """
-  Embeds an html safe raw svg in the markup. Also takes an optional list of CSS
-  attributes and applies those to the svg.
+  Embeds an html safe raw SVG in the markup. Also takes an optional list of CSS
+  attributes and applies those to the SVG.
 
   Ex:
       Brady.inline_svg("test", class: "foo", "data-role": "bar") =>

--- a/lib/brady.ex
+++ b/lib/brady.ex
@@ -54,7 +54,7 @@ defmodule Brady do
   end
 
   defp static_path(file_name) do
-    path = Application.get_env(:brady, :config)[:svg_path]
+    path = Application.get_env(:brady, :svg_path)
     if path do
       "#{path}/#{file_name}.svg"
     else

--- a/lib/brady.ex
+++ b/lib/brady.ex
@@ -20,6 +20,36 @@ defmodule Brady do
     ""
   end
 
+  @doc """
+  """
+  @spec inline_svg(String.t, keyword) :: String.t
+  def inline_svg(file_name, options \\ []) do
+    path = static_path(file_name)
+    case File.read(path) do
+      {:ok, file} -> render_with_options(file, options)
+      {:error, _} -> raise "No SVG found at #{path}"
+    end
+  end
+
+  defp render_with_options(markup, []), do: {:safe, markup}
+  defp render_with_options(markup, options) do
+    markup
+    |> Floki.parse
+    |> Floki.find("svg")
+    |> add_attributes(options)
+    |> Floki.raw_html
+    |> render_with_options([])
+  end
+
+  defp add_attributes([{tag_name, existing_attributes, contents}], attributes) do
+    attributes = Enum.map(attributes, fn{key, value} -> {to_string(key), value} end)
+    {tag_name, attributes ++ existing_attributes, contents}
+  end
+
+  defp static_path(file_name) do
+    "web/static/svg/#{file_name}.svg"
+  end
+
   defp format_path(conn) do
     conn.path_info
     |> remove_numbers

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,7 @@ defmodule Brady.Mixfile do
     [
       {:earmark, "~>0.1", only: :dev},
       {:ex_doc, "~> 0.11", only: :dev},
+      {:floki, "~> 0.13.1"},
       {:phoenix, "~> 1.2"},
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Brady.Mixfile do
     [
       {:earmark, "~>0.1", only: :dev},
       {:ex_doc, "~> 0.11", only: :dev},
-      {:floki, "~> 0.13.1"},
+      {:floki, "~> 0.13"},
       {:phoenix, "~> 1.2"},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "floki": {:hex, :floki, "0.13.1", "b3b287e02914cb41a66285071dade287165ed1915ab07903e18fb454fe961bad", [:mix], [{:mochiweb, "~> 2.15", [hex: :mochiweb, optional: false]}]},
+  "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], []},
   "phoenix": {:hex, :phoenix, "1.2.0", "1bdeb99c254f4c534cdf98fd201dede682297ccc62fcac5d57a2627c3b6681fb", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.0", "c31af4be22afeeebfaf246592778c8c840e5a1ddc7ca87610c41ccfb160c2c57", [:mix], []},
   "plug": {:hex, :plug, "1.1.6", "8927e4028433fcb859e000b9389ee9c37c80eb28378eeeea31b0273350bf668b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},

--- a/test/brady_test.exs
+++ b/test/brady_test.exs
@@ -64,14 +64,20 @@ defmodule BradyTest do
   end
 
   describe "inline_svg" do
+    test "it renders an html safe version of the svg" do
+     assert Brady.inline_svg("test", class: "foo", "data-role": "bar") == test_svg
+    end
+
     test "it returns a runtime error if svg is not found" do
-      message = "No SVG found at web/static/svg/non_existant.svg"
+      message = "No SVG found at test/support/svg/non_existant.svg"
       assert_raise RuntimeError, message, fn ->
         Brady.inline_svg("non_existant")
       end
     end
 
-    def html do
+    def test_svg(options \\ []) do
+      {:safe,
+       "<svg class=\"foo\" data-role=\"bar\" height=\"100\" width=\"100\"><desc>This is a test svg</desc><circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\"></circle></svg>"}
     end
   end
 end

--- a/test/brady_test.exs
+++ b/test/brady_test.exs
@@ -62,4 +62,16 @@ defmodule BradyTest do
       assert Brady.body_class(conn) == "admin-user user user-show"
     end
   end
+
+  describe "inline_svg" do
+    test "it returns a runtime error if svg is not found" do
+      message = "No SVG found at web/static/svg/non_existant.svg"
+      assert_raise RuntimeError, message, fn ->
+        Brady.inline_svg("non_existant")
+      end
+    end
+
+    def html do
+    end
+  end
 end

--- a/test/brady_test.exs
+++ b/test/brady_test.exs
@@ -77,7 +77,7 @@ defmodule BradyTest do
 
     def test_svg(options \\ []) do
       {:safe,
-       ~s(<svg class=\"foo\" data-role=\"bar\" height=\"100\" width=\"100\"><desc>This is a test svg</desc><circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\"></circle></svg>)}
+       ~s(<svg class="foo" data-role="bar" height="100" width="100"><desc>This is a test svg</desc><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></svg>)}
     end
   end
 end

--- a/test/brady_test.exs
+++ b/test/brady_test.exs
@@ -64,11 +64,11 @@ defmodule BradyTest do
   end
 
   describe "inline_svg" do
-    test "it renders an html safe version of the svg" do
+    test "it renders an html safe version of the SVG" do
      assert Brady.inline_svg("test", class: "foo", "data-role": "bar") == test_svg
     end
 
-    test "it returns a runtime error if svg is not found" do
+    test "it returns a runtime error if SVG is not found" do
       message = "No SVG found at test/support/svg/non_existant.svg"
       assert_raise RuntimeError, message, fn ->
         Brady.inline_svg("non_existant")

--- a/test/brady_test.exs
+++ b/test/brady_test.exs
@@ -77,7 +77,7 @@ defmodule BradyTest do
 
     def test_svg(options \\ []) do
       {:safe,
-       "<svg class=\"foo\" data-role=\"bar\" height=\"100\" width=\"100\"><desc>This is a test svg</desc><circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\"></circle></svg>"}
+       ~s(<svg class=\"foo\" data-role=\"bar\" height=\"100\" width=\"100\"><desc>This is a test svg</desc><circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\"></circle></svg>)}
     end
   end
 end

--- a/test/support/svg/test.svg
+++ b/test/support/svg/test.svg
@@ -1,0 +1,4 @@
+<svg height="100" width="100">
+  <desc>This is a test svg</desc>
+  <circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" />
+</svg>


### PR DESCRIPTION
Embeds an html safe raw SVG in the markup. Also takes an optional list of CSS attributes and applies those to the SVG.