### PR TITLE
Support releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Add brady to your list of dependencies in `mix.exs`:
   end
 ```
 
+And configure it in `config.exs`:
+
+```elixir
+  config :brady, otp_app: :my_app
+```
+
 ### Body Class
 
 The body_class function can be used like:
@@ -40,13 +46,15 @@ This will embed the html safe raw SVG in your markup.
 
 `{:safe, ~s(<svg class="foo" data-role="bar" height="100" width="100"><desc>This is a test svg</desc><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"></circle></svg>)}`
 
-By default, it looks for files in `web/static/svg/#{file_name}.svg` but you can
+By default, it looks for files in `priv/static/svg/#{file_name}.svg` but you can
 configure this in your config.exs
 
 ```elixir
   config :brady,
+    otp_app: :my_app,
     svg_path: "web/static/images"
 ```
+
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/lib/brady.ex
+++ b/lib/brady.ex
@@ -54,8 +54,9 @@ defmodule Brady do
   end
 
   defp static_path(file_name) do
-    path = Application.get_env(:brady, :svg_path) || "web/static/svg"
-    Path.join(path, "#{file_name}.svg")
+    app_dir = Application.app_dir(Application.get_env(:brady, :otp_app))
+    path = Application.get_env(:brady, :svg_path) || "priv/static/svg"
+    [app_dir, path, "#{file_name}.svg"] |> Path.join() |> Path.expand
   end
 
   defp format_path(conn) do

--- a/test/brady_test.exs
+++ b/test/brady_test.exs
@@ -3,6 +3,11 @@ defmodule BradyTest do
   alias Plug.Conn
   doctest Brady
 
+  setup do
+    Application.put_env(:brady, :otp_app, :brady)
+    Application.put_env(:brady, :svg_path, "../../../../test/support/svg")
+  end
+
   test "body_class returns controller and action" do
     conn = %Conn{
       private: %{
@@ -69,8 +74,10 @@ defmodule BradyTest do
     end
 
     test "it returns a runtime error if SVG is not found" do
-      message = "No SVG found at test/support/svg/non_existant.svg"
-      assert_raise RuntimeError, message, fn ->
+      assert_raise RuntimeError, ~r|No SVG found at|, fn ->
+        Brady.inline_svg("non_existant")
+      end
+      assert_raise RuntimeError, ~r|support/svg/non_existant.svg|, fn ->
         Brady.inline_svg("non_existant")
       end
     end


### PR DESCRIPTION
Resolves #17 

This will result in a breaking change for other users, since it introduces a required configuration. 

Another change is the default folder, however using `Application.app_dir` should work for Phoenix 1.2, 1.3, and 1.4 since Phoenix symlinks the `priv` folder inside the `_build` folder (which is where `Application.app_dir` would resolve within), but I have not tested this with Phoenix 1.2 to be sure of that.
