### PR TITLE
Update Floki.parse to Floki.parse_fragment!

### DIFF
--- a/lib/brady.ex
+++ b/lib/brady.ex
@@ -81,7 +81,7 @@ defmodule Brady do
   defp render_with_options(markup, []), do: {:safe, markup}
   defp render_with_options(markup, options) do
     markup
-    |> Floki.parse_fragment!()
+    |> Floki.parse_fragment()
     |> Floki.find("svg")
     |> add_attributes(options)
     |> Floki.raw_html

--- a/lib/brady.ex
+++ b/lib/brady.ex
@@ -81,7 +81,7 @@ defmodule Brady do
   defp render_with_options(markup, []), do: {:safe, markup}
   defp render_with_options(markup, options) do
     markup
-    |> Floki.parse
+    |> Floki.parse_fragment!()
     |> Floki.find("svg")
     |> add_attributes(options)
     |> Floki.raw_html

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Brady.Mixfile do
     [
       {:earmark, "~>0.1", only: :dev},
       {:ex_doc, "~> 0.11", only: :dev},
-      {:floki, "0.24.0"},
+      {:floki, "~> 0.24"},
       {:mime, "~> 1.2"},
       {:phoenix, "~> 1.2"}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Brady.Mixfile do
     [
       {:earmark, "~>0.1", only: :dev},
       {:ex_doc, "~> 0.11", only: :dev},
-      {:floki, "~> 0.13"},
+      {:floki, "0.24.0"},
       {:mime, "~> 1.2"},
       {:phoenix, "~> 1.2"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
-  "floki": {:hex, :floki, "0.13.1", "b3b287e02914cb41a66285071dade287165ed1915ab07903e18fb454fe961bad", [:mix], [{:mochiweb, "~> 2.15", [hex: :mochiweb, optional: false]}]},
+  "floki": {:hex, :floki, "0.24.0", "81ec04f66cdc7d142fa8c9f402e4493a25bf9eb8bc39f971f58a8ea84a2e35d3", [:mix], [{:html_entities, "~> 0.5.0", [hex: :html_entities, repo: "hexpm", optional: false]}], "hexpm", "e8a5af967e4a1804bb034ea6e713338adf7bcb082608baae8783f2a41bf754ad"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
   "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], []},
   "phoenix": {:hex, :phoenix, "1.2.0", "1bdeb99c254f4c534cdf98fd201dede682297ccc62fcac5d57a2627c3b6681fb", [:mix], [{:cowboy, "~> 1.0", [repo: "hexpm", hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [repo: "hexpm", hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [repo: "hexpm", hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [repo: "hexpm", hex: :poison, optional: false]}], "hexpm"},


### PR DESCRIPTION
In response to: 
```
==> brady
Compiling 1 file (.ex)
warning: Floki.parse/1 is deprecated. Please use parse_document/1 or parse_fragment/1
  lib/brady.ex:84: Brady.render_with_options/2
```

I wasn't 100% sure whether to prefer `parse_document!/1` or `parse_fragment!/1`, but it looks like Floki handles the input identically, and the context seemed to warrant `_fragment` over `_document`. Happy to discuss though!