### PR TITLE
Correcting types for inline_svg

### DIFF
--- a/lib/brady.ex
+++ b/lib/brady.ex
@@ -30,7 +30,7 @@ defmodule Brady do
       {:safe,
        "<svg class=\"foo\" data-role=\"bar\" height=\"100\" width=\"100\"><desc>This is a test svg</desc><circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\"></circle></svg>"}
   """
-  @spec inline_svg(String.t, keyword) :: String.t
+  @spec inline_svg(String.t, keyword) :: {:safe, String.t}
   def inline_svg(file_name, options \\ []) do
     path = static_path(file_name)
     case File.read(path) do
@@ -90,7 +90,7 @@ defmodule Brady do
 
   defp add_attributes([{tag_name, existing_attributes, contents}], attributes) do
     attributes = Enum.map(attributes, fn{key, value} -> {to_string(key), value} end)
-    {tag_name, attributes ++ existing_attributes, contents}
+    [{tag_name, attributes ++ existing_attributes, contents}]
   end
 
   defp static_path(file_name) do


### PR DESCRIPTION
This PR will resolve Dialyzer errors in dependent projects using the `inline_svg` function. 

First, we correct the return type for the function typespec. This method always returns the `:safe` tuple with a String.

Next, we adjust the type passed to the `Floki.raw_html/1` method to conform to the [typespecs defined in Floki](https://github.com/philss/floki/blob/master/lib/floki.ex#L197). The typespec specifies an `html_tree` [type](https://github.com/philss/floki/blob/master/lib/floki.ex#L70) as the first argument. This is defined as a list wrapping an `html_node` type. However, the function's implementation differs from the typespec as it allows a tuple as well as a list with the former [being wrapped](https://github.com/philss/floki/blob/master/lib/floki/raw_html.ex#L48) automatically in a list. Since both the tuple and list are supported by `Floki.raw_html/1`, I've opted to use the list type here as it matches the currently defined typespec in Floki.

We should also update the typespec in Floki, but this change will fix Dialyzer errors in a backwards compatible and transparent manner until Floki can be updated.